### PR TITLE
ci(gateway): require mock-backed protocol conformance

### DIFF
--- a/.github/workflows/ai-gateway-concurrency.yml
+++ b/.github/workflows/ai-gateway-concurrency.yml
@@ -3,18 +3,8 @@ name: AI Gateway Protocol Conformance Gate
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - '.github/workflows/ai-gateway-concurrency.yml'
-      - 'api/**'
-      - 'scripts/node/ai-gateway-concurrency/**'
-      - 'scripts/node/plugin/**'
   push:
     branches: [dev]
-    paths:
-      - '.github/workflows/ai-gateway-concurrency.yml'
-      - 'api/**'
-      - 'scripts/node/ai-gateway-concurrency/**'
-      - 'scripts/node/plugin/**'
 
 permissions:
   contents: read

--- a/scripts/node/ai-gateway-concurrency/characterize/_tests/engine.test.js
+++ b/scripts/node/ai-gateway-concurrency/characterize/_tests/engine.test.js
@@ -61,7 +61,7 @@ test('AC-003/004/005: finite characterize fixture classifies transports, failure
         return fetch(url, options);
       },
       mockSnapshot: mock.snapshot,
-      timeoutMs: 1_000,
+      timeoutMs: 5_000,
     });
     assert.equal(result.summary.verdict, 'PASS');
     assert.equal(result.summary.performanceBudgetApplied, false);

--- a/scripts/node/ai-gateway-concurrency/workflow-contract/_tests/workflow-source.test.js
+++ b/scripts/node/ai-gateway-concurrency/workflow-contract/_tests/workflow-source.test.js
@@ -16,6 +16,7 @@ test('AC-029: protocol conformance blocks relevant PRs and protected pushes', ()
   assert.match(trigger, /pull_request:/u);
   assert.match(trigger, /push:[\s\S]*branches: \[dev\]/u);
   assert.doesNotMatch(trigger, /schedule:/u);
+  assert.doesNotMatch(trigger, /paths:/u, 'a required check must run for every proposed dev update');
   assert.match(source, /name: AI Gateway Protocol Conformance Gate/u);
 });
 


### PR DESCRIPTION
## Outcome

Make the existing mock-backed AI Gateway protocol conformance workflow a practical required gate for every proposed `dev` update.

## Changes

- cache exact Host and official Provider Rust workspaces with a commit-pinned cache action;
- keep the single repository-owned blocking command and rebuild runtime/package provenance every run;
- run the required workflow for every PR so path filters cannot leave the required check pending;
- add source-contract assertions for cache scope and required-check trigger completeness.

## Online evidence

- cold: https://github.com/taichuy/1flowbase/actions/runs/30472991140 (PASS, 20m31s)
- warm: https://github.com/taichuy/1flowbase/actions/runs/30474603424 (PASS, 9m41s)
- final cold candidate: https://github.com/taichuy/1flowbase/actions/runs/30475684268 (PASS, 20m28s)

No real Provider credential or local client binary is used.