### PR TITLE
ci(quality): include AI Gateway in the global gate

### DIFF
--- a/.github/GITHUB_AUTOMATION.md
+++ b/.github/GITHUB_AUTOMATION.md
@@ -8,6 +8,7 @@ This directory owns GitHub Actions automation for repository quality gates.
 | --- | --- |
 | `.github/workflows/verify.yml` | Automatic merge CI for `pull_request` and `push` to `main` / `latest`; runs lightweight repo tooling, frontend PR, and backend static/fmt/check gates, updates one PR report comment for same-repository pull requests, then publishes one aggregate issue only for `latest` pushes. |
 | `.github/workflows/quality-gate.yml` | Manual and nightly quality gate run; full `ci` scope runs component gates, coverage gates, and container image security in parallel before one aggregate Issue report. |
+| `.github/workflows/ai-gateway-concurrency.yml` | Reusable and standalone AI Gateway protocol conformance gate; remains the required `dev` check and joins full manual/nightly `ci` aggregation. |
 | `.github/workflows/container-images.yml` | Container image CD for `web`, `api-server`, and `plugin-runner`; builds scan-candidate GHCR tags, runs Trivy admission scans, promotes passing images to version and `latest` tags, then uploads artifact-only CD quality gate evidence. |
 | `.github/actions/quality-gate/action.yml` | Reusable repository-local action used by CI, manual, and nightly quality gates. |
 
@@ -129,13 +130,20 @@ environment: leave empty
 For manual `scope: ci`, runs use the full quality gate shape: repo tooling,
 full repo frontend, React Doctor, backend static/fmt/package shards, backend app test
 package shards, backend consistency, frontend coverage, backend coverage package shards,
-state protocols, and container image security run as separate jobs. Scheduled `scope: ci`
+state protocols, container image security, and mock-backed AI Gateway protocol conformance
+run as separate jobs. Scheduled `scope: ci`
 runs use the same component set.
 An aggregate job downloads their artifacts, publishes one Issue report, and uploads
 `test-governance-artifacts`.
 This keeps wall time close to the slowest component gate instead of the sum of all gates.
 Each component job publishes `publish_issue: "false"`; only the aggregate job publishes the
 final report with `publish_issue: "true"`.
+
+AI Gateway conformance remains independently dispatchable and remains the required
+`protocol-conformance` check for `dev`. The full gate invokes the same reusable workflow,
+downloads its standard component report, and lists
+`ai-gateway-protocol-conformance` explicitly in the aggregate component table. It never
+uses real Provider credentials or local client binaries.
 
 For narrower dispatch scopes such as `repo-frontend-pr`, `repo-frontend`, `repo-frontend-react-doctor`, `repo-backend`, `backend-consistency`,
 `coverage-backend`, or `container-images`,

--- a/.github/workflows/ai-gateway-concurrency.yml
+++ b/.github/workflows/ai-gateway-concurrency.yml
@@ -1,6 +1,13 @@
 name: AI Gateway Protocol Conformance Gate
 
 on:
+  workflow_call:
+    inputs:
+      target_ref:
+        description: Candidate branch, tag, or SHA to validate
+        type: string
+        required: false
+        default: ''
   workflow_dispatch:
   pull_request:
   push:
@@ -45,7 +52,13 @@ jobs:
       - name: Checkout candidate source
         uses: actions/checkout@v5
         with:
+          ref: ${{ inputs.target_ref || github.sha }}
           fetch-depth: 1
+
+      - name: Resolve candidate source SHA
+        id: candidate_source
+        shell: bash
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout paired official provider source
         uses: actions/checkout@v6
@@ -76,6 +89,7 @@ jobs:
             tmp/ai-gateway-concurrency/official-source/runtime-extensions/model-providers/openai_compatible -> target
 
       - name: Run the single blocking AI Gateway quality command
+        id: protocol_conformance
         shell: bash
         run: >-
           node scripts/node/ai-gateway-concurrency/quality-gate/cli.js run
@@ -83,13 +97,24 @@ jobs:
           --official-source-root "$GITHUB_WORKSPACE/tmp/ai-gateway-concurrency/official-source"
           --database-url "postgres://postgres:1flowbase@127.0.0.1:5432/1flowbase"
 
+      - name: Write aggregate-compatible AI Gateway report
+        if: always()
+        shell: bash
+        env:
+          AI_GATEWAY_COMMAND_OUTCOME: ${{ steps.protocol_conformance.outcome }}
+        run: >-
+          node scripts/node/ai-gateway-concurrency/quality-gate/component-report.js
+          --repo-root "$GITHUB_WORKSPACE"
+          --command-outcome "$AI_GATEWAY_COMMAND_OUTCOME"
+
       - name: Upload bounded protocol evidence
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: ai-gateway-protocol-conformance-${{ github.sha }}
+          name: test-governance-ai-gateway-protocol-conformance-${{ steps.candidate_source.outputs.sha }}
           path: |
             tmp/test-governance/ai-gateway-quality-gate/**
             tmp/test-governance/ai-gateway-concurrency/**
+            tmp/test-governance/ai-gateway-protocol-conformance/**
           if-no-files-found: error
           retention-days: 14

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -797,6 +797,12 @@ jobs:
           name: test-governance-container-images
           path: tmp/test-governance
 
+  ai-gateway-protocol-conformance:
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.scope == 'ci') }}
+    uses: ./.github/workflows/ai-gateway-concurrency.yml
+    with:
+      target_ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_branch || 'latest' }}
+
   aggregate:
     if: ${{ always() && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.scope == 'ci')) }}
     needs:
@@ -809,6 +815,7 @@ jobs:
       - coverage-backend-gate
       - state-protocols-gate
       - container-images-gate
+      - ai-gateway-protocol-conformance
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -829,7 +836,7 @@ jobs:
           INPUT_ARTIFACT_ROOT: tmp/test-governance/parallel
           INPUT_REPORT_TYPE: ${{ env.QUALITY_GATE_REPORT_TYPE }}
           INPUT_ENVIRONMENT: ${{ github.event_name == 'schedule' && env.QUALITY_GATE_SCHEDULED_ENVIRONMENT || inputs.environment }}
-          INPUT_EXPECTED_SCOPES: 'repo-tooling,repo-frontend,repo-frontend-react-doctor,repo-backend-static,repo-backend-fmt,repo-backend-image-llm-vision,repo-backend-clippy-core-libs,repo-backend-clippy-runtime-storage,repo-backend-clippy-apps,repo-backend-test-core-libs,repo-backend-test-runtime-storage,repo-backend-test-control-plane,repo-backend-test-api-server,repo-backend-test-plugin-runner,repo-backend-check-core-libs,repo-backend-check-runtime-storage,repo-backend-check-apps,backend-consistency,coverage-frontend,coverage-backend-control-plane,coverage-backend-orchestration-runtime,coverage-backend-plugin-runner,coverage-backend-storage-postgres,coverage-backend-api-server,state-protocols,container-images'
+          INPUT_EXPECTED_SCOPES: 'repo-tooling,repo-frontend,repo-frontend-react-doctor,repo-backend-static,repo-backend-fmt,repo-backend-image-llm-vision,repo-backend-clippy-core-libs,repo-backend-clippy-runtime-storage,repo-backend-clippy-apps,repo-backend-test-core-libs,repo-backend-test-runtime-storage,repo-backend-test-control-plane,repo-backend-test-api-server,repo-backend-test-plugin-runner,repo-backend-check-core-libs,repo-backend-check-runtime-storage,repo-backend-check-apps,backend-consistency,coverage-frontend,coverage-backend-control-plane,coverage-backend-orchestration-runtime,coverage-backend-plugin-runner,coverage-backend-storage-postgres,coverage-backend-api-server,state-protocols,container-images,ai-gateway-protocol-conformance'
           INPUT_PUBLISH_ISSUE: "true"
           INPUT_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-artifact@v6

--- a/scripts/node/ai-gateway-concurrency/quality-gate/_tests/component-report.test.js
+++ b/scripts/node/ai-gateway-concurrency/quality-gate/_tests/component-report.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  buildComponentReport,
+  writeComponentReport,
+} = require('../component-report');
+
+const passingGateResult = Object.freeze({
+  status: 'pass',
+  failures: [],
+  main_source_sha: 'candidate-sha',
+  official_source_sha: 'official-sha',
+  blocking_transports: [
+    { id: 'chat-completions-sse', label: 'OpenAI Chat' },
+    { id: 'anthropic-sse', label: 'Anthropic' },
+    { id: 'responses-sse', label: 'Responses SSE' },
+    { id: 'responses-websocket', label: 'Responses WebSocket' },
+  ],
+  official_provider_codes: ['openai', 'anthropic', 'openai_compatible'],
+  protocol_result: {
+    protocol_conformance: {
+      oracle: {
+        rows: 16,
+        protocol_context_profiles: { rows: 9 },
+        error_fidelity: { rows: 20 },
+      },
+      runtime_provenance: { verdict: 'PASS' },
+    },
+  },
+});
+
+test('AC-012: passing gateway evidence becomes an aggregate-compatible component report', () => {
+  const report = buildComponentReport({ commandOutcome: 'success', gateResult: passingGateResult });
+  assert.equal(report.status, 'passed');
+  assert.equal(report.scope, 'ai-gateway-protocol-conformance');
+  assert.equal(report.exitCode, 0);
+  assert.equal(report.protocolConformance.oracleRows, 16);
+  assert.equal(report.protocolConformance.profileRows, 9);
+  assert.equal(report.protocolConformance.errorRows, 20);
+  assert.equal(report.protocolConformance.provenance, 'PASS');
+});
+
+test('AC-012 controlled negatives: command failure or missing evidence fails the aggregate component', () => {
+  assert.equal(buildComponentReport({
+    commandOutcome: 'failure',
+    gateResult: passingGateResult,
+  }).status, 'failed');
+  const missing = buildComponentReport({ commandOutcome: 'success', gateResult: null });
+  assert.equal(missing.status, 'failed');
+  assert.match(missing.failures.join('\n'), /missing quality-gate\.json/u);
+});
+
+test('AC-012: component report writer emits the standard aggregate filenames', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ai-gateway-component-report-'));
+  const paths = writeComponentReport({
+    repoRoot,
+    commandOutcome: 'success',
+    gateResult: passingGateResult,
+  });
+  assert.equal(path.basename(paths.reportPath), 'quality-gate-report.json');
+  assert.equal(path.basename(paths.logPath), 'quality-gate.latest.log');
+  assert.equal(JSON.parse(fs.readFileSync(paths.reportPath, 'utf8')).status, 'passed');
+  assert.match(fs.readFileSync(paths.logPath, 'utf8'), /status=passed/u);
+});

--- a/scripts/node/ai-gateway-concurrency/quality-gate/component-report.js
+++ b/scripts/node/ai-gateway-concurrency/quality-gate/component-report.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const COMPONENT_SCOPE = 'ai-gateway-protocol-conformance';
+
+function buildComponentReport({ commandOutcome, gateResult }) {
+  const gateFailures = Array.isArray(gateResult?.failures)
+    ? gateResult.failures.map((failure) => failure?.message || failure?.name || String(failure))
+    : [];
+  const failures = [];
+  if (commandOutcome !== 'success') failures.push(`blocking command outcome: ${commandOutcome || 'missing'}`);
+  if (!gateResult) failures.push('missing quality-gate.json');
+  if (gateResult && gateResult.status !== 'pass') failures.push(`quality gate status: ${gateResult.status || 'missing'}`);
+  failures.push(...gateFailures);
+
+  const passed = failures.length === 0;
+  const oracle = gateResult?.protocol_result?.protocol_conformance?.oracle;
+  const provenance = gateResult?.protocol_result?.protocol_conformance?.runtime_provenance;
+  return {
+    reportType: 'ci',
+    status: passed ? 'passed' : 'failed',
+    scope: COMPONENT_SCOPE,
+    exitCode: passed ? 0 : 1,
+    mainSourceSha: gateResult?.main_source_sha || '',
+    officialSourceSha: gateResult?.official_source_sha || '',
+    failures,
+    warningFiles: [],
+    coverageSummaries: [],
+    backendConsistencyTargets: [],
+    protocolConformance: {
+      transports: gateResult?.blocking_transports?.map((transport) => transport.id) || [],
+      providers: gateResult?.official_provider_codes || [],
+      oracleRows: oracle?.rows ?? null,
+      profileRows: oracle?.protocol_context_profiles?.rows ?? null,
+      errorRows: oracle?.error_fidelity?.rows ?? null,
+      provenance: provenance?.verdict || null,
+    },
+  };
+}
+
+function writeComponentReport({ repoRoot, commandOutcome, gateResult }) {
+  const outputDir = path.join(
+    repoRoot,
+    'tmp',
+    'test-governance',
+    COMPONENT_SCOPE,
+  );
+  fs.mkdirSync(outputDir, { recursive: true });
+  const report = buildComponentReport({ commandOutcome, gateResult });
+  const reportPath = path.join(outputDir, 'quality-gate-report.json');
+  const logPath = path.join(outputDir, 'quality-gate.latest.log');
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(logPath, [
+    `scope=${report.scope}`,
+    `status=${report.status}`,
+    `exit_code=${report.exitCode}`,
+    `main_source_sha=${report.mainSourceSha || 'missing'}`,
+    ...report.failures.map((failure) => `failure=${failure}`),
+  ].join('\n') + '\n', 'utf8');
+  return { report, reportPath, logPath };
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!name?.startsWith('--') || value === undefined) throw new Error(`invalid argument: ${name || 'missing'}`);
+    values[name.slice(2)] = value;
+  }
+  if (!values['repo-root']) throw new Error('--repo-root is required');
+  if (!values['command-outcome']) throw new Error('--command-outcome is required');
+  return { repoRoot: path.resolve(values['repo-root']), commandOutcome: values['command-outcome'] };
+}
+
+function readGateResult(repoRoot) {
+  const gatePath = path.join(
+    repoRoot,
+    'tmp',
+    'test-governance',
+    'ai-gateway-quality-gate',
+    'quality-gate.json',
+  );
+  if (!fs.existsSync(gatePath)) return null;
+  return JSON.parse(fs.readFileSync(gatePath, 'utf8'));
+}
+
+function main(argv = process.argv.slice(2)) {
+  const inputs = parseArgs(argv);
+  const result = writeComponentReport({
+    ...inputs,
+    gateResult: readGateResult(inputs.repoRoot),
+  });
+  process.stdout.write(`[ai-gateway-component-report] ${result.report.status}: ${result.reportPath}\n`);
+  return result.report.exitCode;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    process.stderr.write(`[ai-gateway-component-report] ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  buildComponentReport,
+  main,
+  parseArgs,
+  readGateResult,
+  writeComponentReport,
+};

--- a/scripts/node/ai-gateway-concurrency/workflow-contract/_tests/workflow-source.test.js
+++ b/scripts/node/ai-gateway-concurrency/workflow-contract/_tests/workflow-source.test.js
@@ -20,6 +20,14 @@ test('AC-029: protocol conformance blocks relevant PRs and protected pushes', ()
   assert.match(source, /name: AI Gateway Protocol Conformance Gate/u);
 });
 
+test('AC-012: protocol conformance remains standalone and is reusable by the global CI gate', () => {
+  assert.match(source, /workflow_call:[\s\S]*target_ref:[\s\S]*type: string/u);
+  assert.match(source, /ref: \$\{\{ inputs\.target_ref \|\| github\.sha \}\}/u);
+  assert.match(source, /id: protocol_conformance/u);
+  assert.match(source, /component-report\.js/u);
+  assert.match(source, /name: test-governance-ai-gateway-protocol-conformance-/u);
+});
+
 test('AC-003/005/006/008/019/024: workflow delegates all blocking checks to one repository command', () => {
   assert.match(source, /Run the single blocking AI Gateway quality command/u);
   assert.match(source, /quality-gate\/cli\.js run/u);

--- a/scripts/node/github-quality-gate/_tests/core.test.js
+++ b/scripts/node/github-quality-gate/_tests/core.test.js
@@ -7,6 +7,7 @@ const path = require('node:path');
 const {
   buildReport,
   buildGateCommand,
+  boundIssueBody,
   buildIssueTitle,
   buildIssueLabels,
   COVERAGE_BACKEND_COMPONENT_SCOPES,
@@ -15,6 +16,15 @@ const {
   runQualityGateAggregate,
   runQualityGate,
 } = require('../core.js');
+
+test('quality gate bounds GitHub Issue bodies while preserving the report summary', () => {
+  const body = `# Quality Gate Report\n\n## Result Summary\n\n${'错误🙂\n'.repeat(30_000)}`;
+  const bounded = boundIssueBody(body);
+  assert.equal(Buffer.byteLength(bounded, 'utf8') <= 60 * 1024, true);
+  assert.match(bounded, /^# Quality Gate Report/u);
+  assert.match(bounded, /Issue report truncated to GitHub’s body limit/u);
+  assert.doesNotMatch(bounded, /\uFFFD/u);
+});
 
 test('buildGateCommand maps supported scopes to repository verify scripts', () => {
   const repoRoot = '/repo';

--- a/scripts/node/github-quality-gate/_tests/workflow-config.test.js
+++ b/scripts/node/github-quality-gate/_tests/workflow-config.test.js
@@ -238,7 +238,7 @@ test("quality gate workflow includes React Doctor in scheduled and manual ci run
   );
   assert.match(
     workflow,
-    /INPUT_EXPECTED_SCOPES: 'repo-tooling,repo-frontend,repo-frontend-react-doctor,[^']*container-images'/u,
+    /INPUT_EXPECTED_SCOPES: 'repo-tooling,repo-frontend,repo-frontend-react-doctor,[^']*container-images,ai-gateway-protocol-conformance'/u,
   );
   assert.match(
     jobBlock,
@@ -444,6 +444,14 @@ test("GitHub automation docs include React Doctor in full ci but not fast verify
   assert.doesNotMatch(readme, /nightly-only/u);
 });
 
+test("GitHub automation docs place reusable AI Gateway conformance in the full ci aggregate", () => {
+  const docs = readGitHubAutomationDocs();
+  assert.match(docs, /ai-gateway-concurrency\.yml/u);
+  assert.match(docs, /ai-gateway-protocol-conformance/u);
+  assert.match(docs, /required\s+`protocol-conformance` check for `dev`/u);
+  assert.match(docs, /never\nuses real Provider credentials or local client binaries/u);
+});
+
 test("GitHub automation docs describe container image CD as artifact-only reporting", () => {
   const readme = readGitHubAutomationDocs();
 
@@ -547,6 +555,10 @@ test("quality gate workflow runs ci scope as parallel component gates before one
     workflow,
     /container-images-gate:\n\s+if: \$\{\{ github\.event_name == 'schedule' \|\| \(github\.event_name == 'workflow_dispatch' && \(inputs\.scope == 'ci' \|\| inputs\.scope == 'container-images'\)\) \}\}/u,
   );
+  assert.match(
+    workflow,
+    /ai-gateway-protocol-conformance:\n\s+if: \$\{\{ github\.event_name == 'schedule' \|\| \(github\.event_name == 'workflow_dispatch' && inputs\.scope == 'ci'\) \}\}[\s\S]*?uses: \.\/\.github\/workflows\/ai-gateway-concurrency\.yml[\s\S]*?target_ref:/u,
+  );
   assert.match(workflow, /- coverage-backend-control-plane/u);
   assert.match(workflow, /- coverage-backend-orchestration-runtime/u);
   assert.match(workflow, /- coverage-backend-plugin-runner/u);
@@ -562,6 +574,7 @@ test("quality gate workflow runs ci scope as parallel component gates before one
   );
   assert.match(workflow, /- state-protocols-gate/u);
   assert.match(workflow, /- container-images-gate/u);
+  assert.match(workflow, /- ai-gateway-protocol-conformance/u);
   assert.match(workflow, /scope: repo-tooling/u);
   assert.match(workflow, /scope: repo-frontend/u);
   assert.match(workflow, /scope: \$\{\{ matrix\.scope \}\}/u);
@@ -591,6 +604,7 @@ test("quality gate workflow runs ci scope as parallel component gates before one
   assert.match(workflow, /INPUT_EXPECTED_SCOPES: .*repo-frontend-react-doctor/u);
   assert.match(workflow, /INPUT_EXPECTED_SCOPES: .*state-protocols/u);
   assert.match(workflow, /INPUT_EXPECTED_SCOPES: .*container-images/u);
+  assert.match(workflow, /INPUT_EXPECTED_SCOPES: .*ai-gateway-protocol-conformance/u);
   assert.match(
     workflow,
     /node scripts\/node\/cli\/github-quality-gate-aggregate\.js/u,

--- a/scripts/node/github-quality-gate/core.js
+++ b/scripts/node/github-quality-gate/core.js
@@ -32,6 +32,7 @@ const SECURITY_RISK_REPORT_FILE = 'security-risk.json';
 const VALID_REPORT_TYPES = new Set(['ci', 'cd']);
 const PR_REPORT_MARKER = '<!-- 1flowbase-quality-gate-pr-report -->';
 const MAX_GATE_OUTPUT_BYTES = 64 * 1024 * 1024;
+const MAX_GITHUB_ISSUE_BODY_BYTES = 60 * 1024;
 const FAILURE_EXCERPT_MAX_LINES = 80;
 const ANSI_CONTROL_SEQUENCE_PATTERN = /\u001b(?:\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001b\\)|[@-Z\\-_])/gu;
 
@@ -113,6 +114,33 @@ function buildIssueLabels({ reportType, status }) {
     `${reportType}-report`,
     status,
   ];
+}
+
+function boundIssueBody(markdown, maxBytes = MAX_GITHUB_ISSUE_BODY_BYTES) {
+  const body = String(markdown || '');
+  if (Buffer.byteLength(body, 'utf8') <= maxBytes) return body;
+
+  const suffix = [
+    '',
+    '---',
+    'Issue report truncated to GitHub’s body limit. Complete component logs and failure details remain in the workflow artifact.',
+    '',
+  ].join('\n');
+  const prefixBudget = maxBytes - Buffer.byteLength(suffix, 'utf8');
+  let low = 0;
+  let high = body.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(body.slice(0, middle), 'utf8') <= prefixBudget) low = middle;
+    else high = middle - 1;
+  }
+  if (
+    low > 0
+    && low < body.length
+    && /[\uD800-\uDBFF]/u.test(body[low - 1])
+    && /[\uDC00-\uDFFF]/u.test(body[low])
+  ) low -= 1;
+  return `${body.slice(0, low).trimEnd()}${suffix}`;
 }
 
 function listFilesBySuffix(rootDir, suffix) {
@@ -919,7 +947,7 @@ async function runQualityGateAggregate({
           status: report.json.status,
           environment: environmentName,
         }),
-        body: report.markdown,
+        body: boundIssueBody(report.markdown),
         labels: buildIssueLabels({
           reportType: normalizedReportType,
           status: report.json.status,
@@ -1056,7 +1084,7 @@ async function runQualityGate({
           status: reportStatus,
           environment: environmentName,
         }),
-        body: report.markdown,
+        body: boundIssueBody(report.markdown),
         labels: buildIssueLabels({
           reportType: normalizedReportType,
           status: reportStatus,
@@ -1112,6 +1140,7 @@ async function runQualityGate({
 module.exports = {
   buildAggregateReport,
   buildGateCommand,
+  boundIssueBody,
   buildIssueLabels,
   buildIssueTitle,
   buildReport,


### PR DESCRIPTION
## Outcome

Make the existing AI Gateway protocol conformance workflow reusable from the manual/nightly global `quality gate` while preserving its standalone required `dev` check.

## Behavior

- manual `quality gate / scope=ci` includes AI Gateway;
- scheduled full CI includes AI Gateway;
- `protocol-conformance` remains independently dispatchable and required on `dev`;
- the aggregate component table includes `ai-gateway-protocol-conformance`; missing or failed evidence fails closed;
- no real Provider credential or local client binary is used.

## Evidence

- Full hosted global run: https://github.com/taichuy/1flowbase/actions/runs/30500510450
- AI Gateway reusable component: PASS and present in the downloaded aggregate report.
- The global run is RED due existing frontend/backend/coverage failures and three timeout-cancelled scopes, not due the gateway integration.
- The run also exposed GitHub Issue body overflow; aggregate Issue bodies are now bounded while complete evidence remains in artifacts.
- Targeted contracts: 43/43 PASS.
